### PR TITLE
feat: create database migrations for core models

### DIFF
--- a/database/migrations/2025_07_02_000627_create_diet_plans_table.php
+++ b/database/migrations/2025_07_02_000627_create_diet_plans_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('diet_plans', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('patient_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->integer('number_of_meals');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_03_091659_create_foods_table.php
+++ b/database/migrations/2025_07_03_091659_create_foods_table.php
@@ -11,12 +11,15 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('meals', function (Blueprint $table) {
+        Schema::create('foods', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('diet_plan_id')->constrained()->onDelete('cascade');
             $table->string('name');
             $table->text('description')->nullable();
-            $table->integer('order');
+            $table->string('unit');
+            $table->decimal('calories', 8, 2);
+            $table->decimal('protein', 8, 2);
+            $table->decimal('carbohydrates', 8, 2);
+            $table->decimal('fats', 8, 2);
             $table->timestamps();
         });
     }
@@ -26,6 +29,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('meals');
+        Schema::dropIfExists('foods');
     }
 };

--- a/database/migrations/2025_07_03_091741_create_meal_food_table.php
+++ b/database/migrations/2025_07_03_091741_create_meal_food_table.php
@@ -11,12 +11,12 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('meals', function (Blueprint $table) {
+        Schema::create('meal_food', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('diet_plan_id')->constrained()->onDelete('cascade');
-            $table->string('name');
-            $table->text('description')->nullable();
-            $table->integer('order');
+            $table->foreignId('meal_id')->constrained()->onDelete('cascade');
+            $table->foreignId('food_id')->constrained()->onDelete('cascade');
+            $table->decimal('quantity', 8, 2);
+            $table->json('manual_nutritional_data')->nullable();
             $table->timestamps();
         });
     }
@@ -26,6 +26,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('meals');
+        Schema::dropIfExists('meal_food');
     }
 };


### PR DESCRIPTION
Esta pull request introduz as migrações de banco de dados para os modelos `DietPlan`, `Meal`, `Food` e a tabela pivot `meal_food`.

As migrações incluem:

*   Criação da tabela `diet_plans` com chave estrangeira para `patients`.
*   Criação da tabela `meals` com chave estrangeira para `diet_plans`.
*   Criação da tabela `foods` com campos para dados nutricionais e unidade.
*   Criação da tabela pivot `meal_food` para relacionar refeições e alimentos, incluindo quantidade e dados nutricionais manuais.
 
Estas migrações estabelecem a estrutura fundamental do banco de dados para o módulo de planos alimentares.

